### PR TITLE
Fix ember warning when passing *Binding options with unquoted values

### DIFF
--- a/app/helpers/liquid-if.js
+++ b/app/helpers/liquid-if.js
@@ -33,11 +33,12 @@ export function factory(invert) {
     }
 
     hash.templates = templates;
-    hash.showFirstBinding = property;
 
     if (isHTMLBars) {
+      hash.showFirst = property;
       env.helpers.view.helperFunction.call(this, [View], hash, options, env);
     } else {
+      hash.showFirstBinding = property;
       return Ember.Handlebars.helpers.view.call(this, View, options);
     }
   };


### PR DESCRIPTION
Ember canary apps currently emit this warning

```
WARNING: You're attempting to render a view by passing showFirstBinding to a view helper without a quoted value, but this syntax is ambiguous. You should either surround showFirstBinding's value in quotes or remove `Binding` from showFirstBinding.
```