### PR TITLE
Update router DSL extension to support canary.

### DIFF
--- a/addon/router-dsl-ext.js
+++ b/addon/router-dsl-ext.js
@@ -28,12 +28,12 @@ proto.modal = function(componentName, opts) {
   });
 };
 
-var origMap = Router.map;
+var origInitRouterJs = Router._initRouterJs;
 
 Router.reopenClass({
-  map: function() {
+  _initRouterJs: function() {
     currentMap = [];
-    var output = origMap.apply(this, arguments);
+    var output = origInitRouterJs.apply(this, arguments);
     this.router.modals = currentMap;
     return output;
   }


### PR DESCRIPTION
Liquid-fire was broken on ember canary due to this refactoring: https://github.com/machty/ember.js/commit/51d80c25a8056a1ae57e130e94632b2db9f4ee52