### PR TITLE
Demo/Docs App: Fix 404 on predefined transitions source code link

### DIFF
--- a/tests/dummy/app/templates/transitions/predefined.hbs
+++ b/tests/dummy/app/templates/transitions/predefined.hbs
@@ -20,4 +20,4 @@ to get you started.</p>
   interruption.</dd>
 </dl>
 
-<p>It may be instructive to <a href="https://github.com/ef4/liquid-fire/tree/master/app-addon/transitions">read the source for these predefined transitions</a>.</p>
+<p>It may be instructive to <a href="https://github.com/ef4/liquid-fire/tree/master/app/transitions">read the source for these predefined transitions</a>.</p>


### PR DESCRIPTION
This is for the link on the [Predefined Transitions page](https://ef4.github.io/liquid-fire/#/transitions/predefined).

Great project, thanks. Cheers!