### PR TITLE
Update to accomodate helper context change.

### DIFF
--- a/app/helpers/liquid-bind.js
+++ b/app/helpers/liquid-bind.js
@@ -1,7 +1,9 @@
 export default {
   isHTMLBars: true,
   helperFunction: function liquidBindHelper(params, hash, options, env) {
-    var componentLookup = this.container.lookup('component-lookup:main');
+    var view = env.data.view;
+
+    var componentLookup = view.container.lookup('component-lookup:main');
     var cls = componentLookup.lookupFactory('liquid-bind-c');
     hash.value = params[0];
     if (hash['class']) {

--- a/app/helpers/liquid-if.js
+++ b/app/helpers/liquid-if.js
@@ -4,9 +4,10 @@ export function factory(invert) {
   return {
     isHTMLBars: true,
     helperFunction: function liquidIfHelper(params, hash, options, env) {
-      var View = this.container.lookupFactory('view:liquid-if');    
+      var view = env.data.view;
+      var View = view.container.lookupFactory('view:liquid-if');
       var templates = [options.template, options.inverse];
-      
+
       if (invert) {
         templates.reverse();
       }

--- a/app/helpers/liquid-outlet.js
+++ b/app/helpers/liquid-outlet.js
@@ -3,6 +3,7 @@ import Ember from "ember";
 export default {
   isHTMLBars: true,
   helperFunction: function liquidOutletHelperFunc(params, hash, options, env) {
+    var view = env.data.view;
     var property = params[0];
 
     if (!property) {
@@ -10,7 +11,7 @@ export default {
       options.paramTypes = ['string'];
     }
 
-    var View = this.container.lookupFactory('view:liquid-outlet');
+    var View = view.container.lookupFactory('view:liquid-outlet');
     if (hash.containerless) {
       View = View.extend(Ember._Metamorph);
     }

--- a/app/helpers/liquid-with.js
+++ b/app/helpers/liquid-with.js
@@ -3,13 +3,14 @@ import Ember from "ember";
 export default {
   isHTMLBars: true,
   helperFunction: function liquidWithHelperFunc(params, hash, options, env) {
+    var view = env.data.view;
     var innerHash = {};
-    var View = this.container.lookupFactory('view:liquid-with');
+    var View = view.container.lookupFactory('view:liquid-with');
     var innerOptions = {
       hashTypes: {},
       morph: options.morph
     };
-    
+
     innerHash.boundContext = params[0];
 
     View = View.extend({

--- a/app/helpers/with-apply.js
+++ b/app/helpers/with-apply.js
@@ -5,17 +5,18 @@ import Ember from "ember";
 export default {
   isHTMLBars: true,
   helperFunction: function withApplyHelperFunc(params, hash, options, env) {
-    var parent = this.get('liquidWithParent');
+    var view = env.data.view;
+    var parent = view.get('liquidWithParent');
     var withArgs = parent.get('originalArgs').slice();
     withArgs[0] = 'lwith-view.boundContext';
     options = Ember.copy(options);
-    if (!this._keywords) {
-      this._keywords = {};
+    if (!view._keywords) {
+      view._keywords = {};
     }
-    this._keywords['lwith-view'] = this;
+    view._keywords['lwith-view'] = view;
     options.template = parent.get('innerTemplate');
     hash = parent.get('originalHash');
     options.hashTypes = parent.get('originalHashTypes');
-    env.helpers.with.helperFunction.call(this, [this.getStream(withArgs[0])], hash, options, env);
+    env.helpers.with.helperFunction.call(this, [view.getStream(withArgs[0])], hash, options, env);
   }
 };


### PR DESCRIPTION
Helper's context will be `undefined` soon, in preparation for a larger refactoring of views + helpers that is hopefully going to land in Ember 1.12.

This PR makes sure that liquid-fire will function after that change.  `env.data.view` has been available since 1.10.0-beta.1, so this is safe for all HTMLBars Ember versions.