### PR TITLE
Fix for liquid-spacer growth instability

### DIFF
--- a/app/components/liquid-measured.js
+++ b/app/components/liquid-measured.js
@@ -8,8 +8,7 @@ export default Ember.Component.extend({
 
     // This prevents margin collapse
     this.$().css({
-      border: '1px solid transparent',
-      margin: '-1px'
+      overflow: 'hidden'
     });
 
     this.didMutate();
@@ -39,8 +38,7 @@ export default Ember.Component.extend({
     var elt = this.$();
     if (!elt || !elt[0]) { return; }
     this.set('measurements', measure(elt));
-  }  
-
+  }
 });
 
 export function measure($elt) {

--- a/tests/acceptance/scenarios-test.js
+++ b/tests/acceptance/scenarios-test.js
@@ -27,6 +27,21 @@ test('nested liquid-outlets wait for their ancestors to animate', function() {
   });
 });
 
+test('Test width does not change when re-measuring', function() {
+  visit('/scenarios/spacer');
+  andThen(function(){
+    Ember.run.later(function(){
+      var initialWidth = find('#spacer-test-2 .ember-view:nth-child(2)').outerWidth();
+      andThen(function(){
+          click('.ember-checkbox');
+          andThen(function(){
+              equal(find('#spacer-test-2 .ember-view:nth-child(2)').outerWidth(), initialWidth, "Width has changed during re-calculation");
+          });
+      });
+    }, 30);
+  });
+});
+
 test('inner nested liquid-outlets can animate', function() {
   visit('/scenarios/nested-outlets/middle/inner');
   visit('/scenarios/nested-outlets/middle');

--- a/tests/dummy/app/controllers/scenarios/spacer.js
+++ b/tests/dummy/app/controllers/scenarios/spacer.js
@@ -2,6 +2,9 @@ import Ember from "ember";
 export default Ember.Controller.extend({
   count: 1,
   things: [{number: 0}],
+  longMessage: "This is a long message. This is a long message. This is a long message. This is a long message. This is a long message. This is a long message. This is a long message. This is a long message. ",
+  shortMessage: "Hi.",
+  showLongMessage: true,
   
   actions: {
     addThing: function() {

--- a/tests/dummy/app/styles/_scenarios.scss
+++ b/tests/dummy/app/styles/_scenarios.scss
@@ -39,11 +39,18 @@ td {
     border: 1px solid black;
 }
 
-#spacer-test {
+#spacer-test-1 {
     border: 1px solid black;
     ol {
         padding: 0 2em;
     }
+}
+
+
+#spacer-test-2 {
+    border: 1px solid black;
+    width: 20em;
+    padding: 0.5em 1.5em;
 }
 
 #versions-test {

--- a/tests/dummy/app/templates/scenarios/spacer.hbs
+++ b/tests/dummy/app/templates/scenarios/spacer.hbs
@@ -1,10 +1,21 @@
 <button {{action "addThing"   }}>More Things</button>
 <button {{action "removeThing"}}>Less Things</button>
 
-{{#liquid-spacer id="spacer-test"}}
+{{#liquid-spacer id="spacer-test-1"}}
   <ol>
   {{#each thing in things}}
     <li>{{thing.number}}</li>
   {{/each}}
   </ol>
 {{/liquid-spacer}}
+
+<div id="spacer-test-2">
+  <label>{{input type="checkbox" checked=showLongMessage}} Show Long Message</label>
+  {{#liquid-spacer}}
+    {{#if showLongMessage}}
+      {{longMessage}}
+    {{else}}
+      {{shortMessage}}
+    {{/if}}
+  {{/liquid-spacer}}
+</div>


### PR DESCRIPTION
This closes #211 by switching to a different technique for preventing margin collapse. The negative margins were giving inconsistent results in different browsers.