### PR TITLE
fixing deprecation of this.pickFiles and this.mergeTrees

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@
 
 var checker = require('ember-cli-version-checker');
 var path = require('path');
+var mergeTrees = require('broccoli-merge-trees');
+var pickFiles = require('broccoli-static-compiler');
 
 module.exports = {
   name: 'liquid-fire',
@@ -13,11 +15,11 @@ module.exports = {
 
   treeForVendor: function(tree){
     var velocityPath = path.dirname(require.resolve('velocity-animate'));
-    var velocityTree = this.pickFiles(this.treeGenerator(velocityPath), {
+    var velocityTree = pickFiles(this.treeGenerator(velocityPath), {
       srcDir: '/',
       destDir: 'velocity'
     });
-    return this.mergeTrees([tree, velocityTree]);
+    return mergeTrees([tree, velocityTree]);
   },
 
   included: function(app){

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "author": "Edward Faulkner <ef@alum.mit.edu>",
   "license": "MIT",
   "dependencies": {
+    "broccoli-merge-trees": "^0.2.1",
+    "broccoli-static-compiler": "^0.2.1",
     "ember-cli-babel": "4.1.0",
     "ember-cli-htmlbars": "^0.7.4",
     "ember-cli-version-checker": "^1.0.2",


### PR DESCRIPTION
fixes the following console warnings
```
[Deprecated] this.pickFiles is deprecated, please use broccoli-funnel directly instead  [addon: liquid-fire]
[Deprecated] this.mergeTrees is deprecated, please use broccoli-merge-trees directly instead  [addon: liquid-fire]
```