### PR TITLE
Fix `fromModel` to `fromModal` in modal docs

### DIFF
--- a/tests/dummy/app/templates/modal-documentation/animation.hbs
+++ b/tests/dummy/app/templates/modal-documentation/animation.hbs
@@ -9,6 +9,6 @@ built-in rule looks like this:</p>
 <p>It uses the {{#link-to "transitions.explode"}}explode{{/link-to}}
 transition to separately animate the dialog box's container (which has class <code>lm-container</code>) and the background overlay (which has class <code>lf-overlay</code>).</p>
 
-<p>There are also <code>fromModel</code> and <code>toModal</code>
+<p>There are also <code>fromModal</code> and <code>toModal</code>
 constraints that will match the name of the modal component that is
 coming or going.</p>


### PR DESCRIPTION
`fromModel` also exists but here the page talks about modals, so it should be `fromModal`.