### PR TITLE
Switch inline style attribute binding to jQuery CSS DOM Manip for CSP

### DIFF
--- a/app/components/liquid-child.js
+++ b/app/components/liquid-child.js
@@ -1,10 +1,16 @@
 import Ember from "ember";
 export default Ember.Component.extend({
   classNames: ['liquid-child'],
-  attributeBindings: ['style'],
-  style: Ember.computed('visible', function() {
-    return new Ember.Handlebars.SafeString(this.get('visible') ? '' : 'visibility:hidden');
-  }),
+
+  updateElementVisibility: function() {
+    let visible = this.get('visible');
+    let $container = this.$();
+
+    if ($container && $container.length) {
+      $container.css('visibility', visible ? 'visible' : 'hidden');
+    }
+  }.on('willInsertElement').observes('visible'),
+
   tellContainerWeRendered: Ember.on('didInsertElement', function(){
     this.sendAction('didRender', this);
   })


### PR DESCRIPTION
This fixes #264 by using DOM APIs for style access. I didn't find other places in the code where inline style attributes are used. It passes all tests, but I'm not sure if this particular feature is tested in the tests (or how to really test it myself). So I'd love if someone could verify that this does what the old one did.

Thanks!