### PR TITLE
Update transition-arguments.js

### DIFF
--- a/tests/dummy/snippets/transition-arguments.js
+++ b/tests/dummy/snippets/transition-arguments.js
@@ -1,7 +1,7 @@
 /* app/transitions/my-animation.js */
 export default function(color, opts) {
   //...
-});
+}
 
 /* within app/transitions.js */
 this.transition(


### PR DESCRIPTION
nothing to close with the right paren.  export default function doesn't need semicolon afterwards either