### PR TITLE
matchBy data elements whose value needs quotes

### DIFF
--- a/app/transitions/explode.js
+++ b/app/transitions/explode.js
@@ -145,12 +145,16 @@ function matchAndExplode(context, piece, seen) {
 
   // use the fastest selector available
   var selector;
+
   if (piece.matchBy === 'id') {
     selector = (attrValue) => { return `#${attrValue}`; };
   } else if (piece.matchBy === 'class') {
     selector = (attrValue) => { return `.${attrValue}`; };
   } else {
-    selector = (attrValue) => { return `[${piece.matchBy}=${attrValue}]`; };
+    selector = (attrValue) => {
+      var escapedAttrValue = attrValue.replace(/'/g, "\\'");
+      return `[${piece.matchBy}='${escapedAttrValue}']`;
+    };
   }
 
   var hits = Ember.A(context.oldElement.find(`[${piece.matchBy}]`).toArray());

--- a/tests/integration/transitions/explode-test.js
+++ b/tests/integration/transitions/explode-test.js
@@ -236,6 +236,36 @@ test("it can matchBy data attribute", function(assert) {
   return tmap.waitUntilIdle();
 });
 
+test("it can matchBy data elements whose value needs quotes", function(assert) {
+  expect(4);
+  tmap.map(function() {
+    this.transition(
+      this.hasClass('explode-transition-test'),
+      this.use('explode', {
+        matchBy: 'data-model-name',
+        use: function() {
+          var oldText = this.oldElement && this.oldElement.text();
+          var newText = this.newElement && this.newElement.text();
+          assert.ok(/Old/.test(oldText), "old text");
+          assert.ok(/New/.test(newText), "new text");
+          return Ember.RSVP.resolve();
+        }
+      })
+    );
+  });
+  this.render(`
+              {{#liquid-if otherMode class="explode-transition-test"}}
+                <div data-model-name="Smith, Granny">New One</div>
+                <div data-model-name="Appleseed, Johnny's">New Two</div>
+              {{else}}
+                <div data-model-name="Smith, Granny">Old One</div>
+                <div data-model-name="Appleseed, Johnny's">Old Two</div>
+              {{/liquid-if}}
+              `);
+  this.set('otherMode', true);
+  return tmap.waitUntilIdle();
+});
+
 test("matchBy only animates when both sides match", function(assert) {
   expect(0);
   tmap.map(function() {


### PR DESCRIPTION
Addresses an issue When using matchBy if a data-element required
quotes, the matchBy would fail.

```html
<h2 class="panel-title" data-fullname="Burawa, Danny">Burawa, Danny</h2>
```

Matching on data-fullname would previously fail. This commit takes
the attribute value escapes single quotes, and the wraps the attribute
value in single quotes before searching.

Should fix [#292]