### PR TITLE
Fix #298: respect `enableGrowth=false`

### DIFF
--- a/app/components/liquid-container.js
+++ b/app/components/liquid-container.js
@@ -72,6 +72,7 @@ export default Ember.Component.extend(Growable, {
 
     afterChildInsertion: function(versions) {
       var elt = this.$();
+      var enableGrowth = this.get('enableGrowth') !== false;
 
       // Measure  children
       var sizes = [];
@@ -87,7 +88,14 @@ export default Ember.Component.extend(Growable, {
       var have = this._cachedSize || want;
 
       // Make ourself absolute
-      this.lockSize(elt, have);
+      if (enableGrowth) {
+        this.lockSize(elt, have);
+      } else {
+        this.lockSize(elt, {
+          height: Math.max(want.height, have.height),
+          width: Math.max(want.width, have.width),
+        });
+      }
 
       // Make the children absolute and fixed size.
       for (i = 0; i < versions.length; i++) {
@@ -95,7 +103,9 @@ export default Ember.Component.extend(Growable, {
       }
 
       // Kick off our growth animation
-      this._scaling = this.animateGrowth(elt, have, want);
+      if (enableGrowth) {
+        this._scaling = this.animateGrowth(elt, have, want);
+      }
     },
 
     afterTransition: function(versions) {


### PR DESCRIPTION
If you grep the repo before this change, you'll realize there is no code to actually lookup and respect the `enableGrowth` setting.

I restored some logic that was lost along the way in the past.