### PR TITLE
Add `outletName` constraint

### DIFF
--- a/addon/constrainables.js
+++ b/addon/constrainables.js
@@ -38,6 +38,7 @@ export default {
     }
   },
   helperName: {},
+  outletName: {},
   parentElementClass: {
     accessor: function(conditions) {
       var cls = conditions.parentElement.attr('class');

--- a/addon/dsl.js
+++ b/addon/dsl.js
@@ -115,6 +115,10 @@ export default class DSL {
     return new Constraint('helperName', names);
   }
 
+  outletName(...names) {
+    return new Constraint('outletName', names);
+  }
+
   toModal(matcher) {
     return new Constraint('newModalComponent', matcher);
   }

--- a/app/components/liquid-versions.js
+++ b/app/components/liquid-versions.js
@@ -73,7 +73,8 @@ export default Ember.Component.extend({
       // "match anything truthy/falsy" predicates, whereas string
       // checks are a direct object property lookup.
       firstTime: firstTime ? 'yes' : 'no',
-      helperName: get(this, 'name')
+      helperName: get(this, 'name'),
+      outletName: get(this, 'outletName')
     });
 
     if (this._runningTransition) {

--- a/app/templates/components/liquid-bind.hbs
+++ b/app/templates/components/liquid-bind.hbs
@@ -1,5 +1,6 @@
 {{#if containerless}}
   {{~#liquid-versions value=attrs.value use=use
+                     outletName=attrs.outletName
                      name="liquid-bind" renderWhenFalse=true class=class as |version| ~}}
     {{~#if hasBlock}}
       {{~yield version ~}}
@@ -18,6 +19,7 @@
       enableGrowth=enableGrowth
       as |container| ~}}
     {{~#liquid-versions value=attrs.value notify=container use=use
+                       outletName=attrs.outletName
                        name="liquid-bind" renderWhenFalse=true as |version| ~}}
 
       {{~#if hasBlock}}

--- a/app/templates/components/liquid-outlet.hbs
+++ b/app/templates/components/liquid-outlet.hbs
@@ -4,6 +4,7 @@
       class=class
       use=use
       name="liquid-outlet"
+      outletName=outletName
       containerless=containerless
       growDuration=growDuration
       growPixelsPerSecond=growPixelsPerSecond

--- a/tests/acceptance/scenarios-test.js
+++ b/tests/acceptance/scenarios-test.js
@@ -33,6 +33,12 @@ test('inner nested liquid-outlets can animate', function() {
   });
 });
 
+test('liquid-outlet animate by outlet name', function() {
+  visit('/scenarios/in-test-outlet');
+  andThen(function(){
+    ranTransition('toLeft');
+  });
+});
 
 test('modal with remapped parameters receives them', function() {
   expect(2);

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -97,6 +97,7 @@ Router.map(function() {
       this.route('two');
       this.route('three');
     });
+    this.route('in-test-outlet');
   });
 
 });

--- a/tests/dummy/app/routes/scenarios/in-test-outlet.js
+++ b/tests/dummy/app/routes/scenarios/in-test-outlet.js
@@ -1,0 +1,12 @@
+import Ember from "ember";
+
+export default Ember.Route.extend({
+  renderTemplate(controller, model) {
+    this.render({
+      into: 'scenarios',
+      outlet: 'test',
+      controller: controller,
+      model: model
+    });
+  }
+});

--- a/tests/dummy/app/templates/scenarios.hbs
+++ b/tests/dummy/app/templates/scenarios.hbs
@@ -1,0 +1,2 @@
+{{outlet}}
+{{liquid-outlet "test"}}

--- a/tests/dummy/app/templates/scenarios/in-test-outlet.hbs
+++ b/tests/dummy/app/templates/scenarios/in-test-outlet.hbs
@@ -1,0 +1,1 @@
+in-test-outlet

--- a/tests/dummy/app/transitions.js
+++ b/tests/dummy/app/transitions.js
@@ -152,6 +152,12 @@ export default function(){
   );
 
   this.transition(
+    this.includingInitialRender(),
+    this.outletName('test'),
+    this.use('toLeft')
+  );
+
+  this.transition(
     this.withinRoute(/^scenarios.model-dependent-rule\./),
     this.fromModel(function(fromModel, toModel) {
       return fromModel && toModel && parseInt(fromModel.id) < parseInt(toModel.id);

--- a/tests/unit/libs/dsl-test.js
+++ b/tests/unit/libs/dsl-test.js
@@ -316,6 +316,19 @@ test("matches routes by regex", function(){
   expectAnimation(routes('foo.bar', 'foo.baz'), dummyAction);
 });
 
+test("matches routes by outletName", function(){
+  t.map(function(){
+    this.transition(
+      this.outletName('panel'),
+      this.use(dummyAction)
+    );
+  });
+
+  var conditions = routes('one', 'two');
+  conditions.outletName = 'panel';
+  expectAnimation(conditions, dummyAction);
+});
+
 
 function dummyAction() {}
 function otherAction() {}


### PR DESCRIPTION
Example

```hbs
{{liquid-outlet 'panel'}}
```

```js
//transitions.js
this.transition(
  this.includingInitialRender(),
  this.outletName('panel'),
  this.use('crossFade')
);
```

See #340 for context