### PR TITLE
Stop redefining $

### DIFF
--- a/addon/tabbable.js
+++ b/addon/tabbable.js
@@ -12,8 +12,6 @@
 
 import Ember from 'ember';
 
-var $ = Ember.$;
-
 function focusable( element, isTabIndexNotNaN ) {
   var nodeName = element.nodeName.toLowerCase();
   return ( /input|select|textarea|button|object/.test( nodeName ) ?
@@ -24,16 +22,16 @@ function focusable( element, isTabIndexNotNaN ) {
 }
 
 function visible(element) {
-  var $el = $(element);
-  return $.expr.filters.visible(element) &&
-    !$($el, $el.parents()).filter(function() {
-      return $.css( this, "visibility" ) === "hidden";
+  var $el = Ember.$(element);
+  return Ember.$.expr.filters.visible(element) &&
+    !Ember.$($el, $el.parents()).filter(function() {
+      return Ember.$.css( this, "visibility" ) === "hidden";
     }).length;
 }
 
-if (!$.expr[':'].tabbable) {
-  $.expr[':'].tabbable = function( element ) {
-    var tabIndex = $.attr( element, "tabindex" ),
+if (!Ember.$.expr[':'].tabbable) {
+  Ember.$.expr[':'].tabbable = function( element ) {
+    var tabIndex = Ember.$.attr( element, "tabindex" ),
       isTabIndexNaN = isNaN( tabIndex );
     return ( isTabIndexNaN || tabIndex >= 0 ) && focusable( element, !isTabIndexNaN );
   };

--- a/tests/dummy/app/components/grid-overlay.js
+++ b/tests/dummy/app/components/grid-overlay.js
@@ -1,13 +1,11 @@
 import Ember from "ember";
 
-var $ = Ember.$;
-
 function show_lead(space, offset) {
-  var max = $(document).height() / space;
+  var max = Ember.$(document).height() / space;
   hide_lead();
   for (var i = 0; i < max; i++) {
-    $('body').append("<div class='grid' id='vgrid" + i + "'></div>");
-    $("#vgrid" + i).css({
+    Ember.$('body').append("<div class='grid' id='vgrid" + i + "'></div>");
+    Ember.$("#vgrid" + i).css({
       height: "" + space + "px",
       width: "100%",
       position: "absolute",
@@ -23,14 +21,14 @@ function show_lead(space, offset) {
 }
 
 function hide_lead() {
-  $('.grid').remove();
+  Ember.$('.grid').remove();
 }
 
 function toggleGrid(leading, leading_offset) {
   if (leading_offset == null) {
     leading_offset = 0;
   }
-  if ($("#vgrid0").length > 0) {
+  if (Ember.$("#vgrid0").length > 0) {
     return hide_lead();
   } else {
     return show_lead(leading, leading_offset);
@@ -39,7 +37,7 @@ function toggleGrid(leading, leading_offset) {
 
 export default Ember.Component.extend({
   didInsertElement: function(){
-    $(document).bind('keydown', function(e){
+    Ember.$(document).bind('keydown', function(e){
       // Ctrl-Alt-g shows vertical rhythm
       if (e.ctrlKey && e.altKey && e.keyCode === 71) {
         toggleGrid(22);


### PR DESCRIPTION
We have $ defined as an allowed global in our apps .jshintrc which throws an error when liquid-fire is included.  
```
modules/liquid-fire/tabbable.js should pass jshint.
modules/liquid-fire/tabbable.js: line 15, col 5, Redefinition of '$'.
```

Since both of these files are self contained the easiest solution seemed to be to just use Ember.$ instead of $.  This kept me from having to learn about how scope works with a module.  I'm happy to do it another way though if you prefer.

I believe this fixes #370