### PR TITLE
Improved documentation for predefined transitions

### DIFF
--- a/tests/dummy/app/controllers/transitions/predefined.js
+++ b/tests/dummy/app/controllers/transitions/predefined.js
@@ -1,0 +1,15 @@
+import Ember from "ember";
+
+export default Ember.Controller.extend({
+  showDetail: false,
+  activeTab: 'toLeft',
+
+  actions: {
+    toggleDetail: function() {
+      this.toggleProperty('showDetail');
+    },
+    changeTab(tabName){
+      this.set('activeTab', tabName);
+    }
+  }
+});

--- a/tests/dummy/app/controllers/transitions/predefined.js
+++ b/tests/dummy/app/controllers/transitions/predefined.js
@@ -5,7 +5,7 @@ export default Ember.Controller.extend({
   activeTab: 'toLeft',
 
   actions: {
-    toggleDetail: function() {
+    toggleDetail() {
       this.toggleProperty('showDetail');
     },
     changeTab(tabName){

--- a/tests/dummy/app/styles/_demos.scss
+++ b/tests/dummy/app/styles/_demos.scss
@@ -100,3 +100,7 @@
         height: 150px;
     }
 }
+
+#transition-examples{
+  margin-top: 1em;
+}

--- a/tests/dummy/app/templates/transitions/predefined.hbs
+++ b/tests/dummy/app/templates/transitions/predefined.hbs
@@ -1,30 +1,265 @@
 <h2>Predefined Transitions</h2>
 
 <p>The library includes a small set of predefined transitions. They
-are intended as a starting point, and you are encouraged to add your
-own transitions that expand up on them.</p>
+    are intended as a starting point, and you are encouraged to add your
+    own transitions that expand up on them.</p>
+<p> For more information about these transitions, you can <a href="https://github.com/ef4/liquid-fire/tree/master/app/transitions">read the source code</a>.</p>
 
-<dl class="dl-horizontal">
-  <dt>toLeft, toRight, toUp, toDown</dt>
-  <dd>These are slide animations powered by the
-  CSS <code>transform</code> property. They all accept an optional
-  hash that's passed onward to Velocity for both the outgoing and
-  incoming animations.</dd>
+<ul class="nav nav-tabs" role="tablist">
+    <li role="presentation" class={{if (is-equal activeTab 'toLeft') 'active'}}>
+        <a href="#" aria-controls="home" role="tab" data-toggle="tab" {{action 'changeTab' 'toLeft'}}>
+            toLeft, toRight, toUp, toDown</a>
+    </li>
+    <li role="presentation" class={{if (is-equal activeTab 'fade') 'active'}}>
+        <a href="#profile" aria-controls="profile" role="tab" data-toggle="tab" {{action 'changeTab' 'fade'}}>
+            fade
+        </a>
+    </li>
+    <li role="presentation" class={{if (is-equal activeTab 'crossFade') 'active'}}>
+        <a href="#messages" aria-controls="messages" role="tab" data-toggle="tab" {{action 'changeTab' 'crossFade'}}>
+            crossFade
+        </a>
+    </li>
+    <li role="presentation" class={{if (is-equal activeTab 'explode') 'active'}}>
+        <a href="#messages" aria-controls="messages" role="tab" data-toggle="tab" {{action 'changeTab' 'explode'}}>
+            explode
+        </a>
+    </li>
+    <li role="presentation" class={{if (is-equal activeTab 'flyTo') 'active'}}>
+        <a href="#messages" aria-controls="messages" role="tab" data-toggle="tab" {{action 'changeTab' 'flyTo'}}>
+            flyTo
+        </a>
+    </li>
+    <li role="presentation" class={{if (is-equal activeTab 'scrollThen') 'active'}}>
+        <a href="#messages" aria-controls="messages" role="tab" data-toggle="tab" {{action 'changeTab' 'scrollThen'}}>
+            scrollThen
+        </a>
+    </li>
+    <li role="presentation" class={{if (is-equal activeTab 'scale') 'active'}}>
+        <a href="#messages" aria-controls="messages" role="tab" data-toggle="tab" {{action 'changeTab' 'scale'}}>
+            scale
+        </a>
+    </li>
+</ul>
 
-  <dt>crossFade</dt>
-  <dd>Old content fades away toward opacity 0 while new content fades
-  in.</dd>
+<div id="transition-examples">
 
-  <dt>fade</dt>
-  <dd>Old content fades away toward opacity 0, then new content fades
-  in. This is a good example of a serial animation with support for
-  interruption.</dd>
+  {{#if (is-equal activeTab 'toLeft')}}
+      <dt>toLeft, toRight, toUp, toDown</dt>
+      <dd>These are slide animations powered by the
+          CSS <code>transform</code> property. They all accept an optional
+          options hash that's passed onward to Velocity for both the outgoing and
+          incoming animations. For more information about available options, please refer to <a
+                  href="http://julian.com/research/velocity/#duration" target="_blank">official Velocity
+              documentation</a>.
+      </dd>
 
-  <dt>{{#link-to "transitions.explode"}}explode{{/link-to}}</dt><dd>This lets you break apart an element and use
-    other transitions on each of the separate pieces.</dd>
+      <div class="well">
+        {{!- BEGIN-SNIPPET toLeft-demo }}
+          <div class="panel panel-default">
+              <div class="panel-body">
+                  <button {{action "toggleDetail"}}>Toggle Detail View</button>
+                {{#liquid-if showDetail class='toLeft-demo'}}
+                    <div class="details">
+                        <h3>Details</h3>
 
-  <dt>fly-to</dt>
-  <dd>Animates the old content's position and dimensions to match the new content's position and dimensions. If either old content or new content is empty, does nothing.</dd>
-</dl>
+                        <p>
+                            Bacon ipsum dolor amet shank pork belly boudin flank
+                            prosciutto alcatra andouille pig short ribs biltong kevin
+                            salami tail turkey beef ribs.
+                        </p>
+                    </div>
+                {{else}}
+                    <div class="overview">
+                        <h3>Welcome</h3>
 
-<p>It may be instructive to <a href="https://github.com/ef4/liquid-fire/tree/master/app/transitions">read the source for these predefined transitions</a>.</p>
+                        <p>This is the overview.</p>
+                    </div>
+                {{/liquid-if}}
+              </div>
+          </div>
+        {{!- END-SNIPPET }}
+
+          <p>The transition rule:</p>
+        {{code-snippet name="toLeft-demo.js"}}
+
+          <p>The template:</p>
+        {{code-snippet name="toLeft-demo.hbs"}}
+      </div>
+  {{/if}}
+
+  {{#if (is-equal activeTab 'crossFade')}}
+      <dt>crossFade</dt>
+      <dd>Old content fades away toward opacity 0 while new content fades
+          in.
+      </dd>
+
+      <div class="well">
+        {{!- BEGIN-SNIPPET crossFade-demo }}
+          <div class="panel panel-default">
+              <div class="panel-body">
+                  <button {{action "toggleDetail"}}>Toggle Detail View</button>
+                {{#liquid-if showDetail class='crossFade-demo'}}
+                    <div class="details">
+                        <h3>Details</h3>
+
+                        <p>
+                            Bacon ipsum dolor amet shank pork belly boudin flank
+                            prosciutto alcatra andouille pig short ribs biltong kevin
+                            salami tail turkey beef ribs.
+                        </p>
+                    </div>
+                {{else}}
+                    <div class="overview">
+                        <h3>Welcome</h3>
+
+                        <p>This is the overview.</p>
+                    </div>
+                {{/liquid-if}}
+              </div>
+          </div>
+        {{!- END-SNIPPET }}
+
+          <p>The transition rule:</p>
+        {{code-snippet name="crossFade-demo.js"}}
+
+          <p>The template:</p>
+        {{code-snippet name="crossFade-demo.hbs"}}
+      </div>
+  {{/if}}
+
+  {{#if (is-equal activeTab 'fade')}}
+      <dt>fade</dt>
+      <dd>Old content fades away toward opacity 0, then new content fades
+          in. This is a good example of a serial animation with support for
+          interruption.
+      </dd>
+
+      <div class="well">
+        {{!- BEGIN-SNIPPET fade-demo }}
+          <div class="panel panel-default">
+              <div class="panel-body">
+                  <button {{action "toggleDetail"}}>Toggle Detail View</button>
+                {{#liquid-if showDetail class='fade-demo'}}
+                    <div class="details">
+                        <h3>Details</h3>
+
+                        <p>
+                            Bacon ipsum dolor amet shank pork belly boudin flank
+                            prosciutto alcatra andouille pig short ribs biltong kevin
+                            salami tail turkey beef ribs.
+                        </p>
+                    </div>
+                {{else}}
+                    <div class="overview">
+                        <h3>Welcome</h3>
+
+                        <p>This is the overview.</p>
+                    </div>
+                {{/liquid-if}}
+              </div>
+          </div>
+        {{!- END-SNIPPET }}
+
+          <p>The transition rule:</p>
+        {{code-snippet name="fade-demo.js"}}
+
+          <p>The template:</p>
+        {{code-snippet name="fade-demo.hbs"}}
+      </div>
+  {{/if}}
+
+  {{#if (is-equal activeTab 'explode')}}
+      <dt>explode</dt>
+      <dd>This lets you break apart an element and use
+          other transitions on each of the separate pieces.
+          <br/>
+          For an interactive example, please visit {{#link-to "transitions.explode"}}this page{{/link-to}}.
+      </dd>
+  {{/if}}
+
+  {{#if (is-equal activeTab 'flyTo')}}
+      <dt>fly-to</dt>
+      <dd>Animates the old content's position and dimensions to match the new content's position and dimensions. If
+          either
+          old content or new content is empty, does nothing.
+          <br/>
+          For an interactive example, please visit {{#link-to "transitions.explode"}}this page{{/link-to}}.
+      </dd>
+  {{/if}}
+
+  {{#if (is-equal activeTab 'scrollThen')}}
+      <dt>scrollThen</dt>
+      <dd>Scrolls to the top of the page and after that runs the specified transition. It is also able to pass <a
+              href="http://julian.com/research/velocity/#duration" target="_blank">Velocity options</a> to the follow-up
+          transition. <p><b>Note:</b> to run the example below, try to scroll the page a bit and then press
+              the button to trigger the transition.</p></dd>
+      <div class="well">
+        {{!- BEGIN-SNIPPET scrollThen-demo }}
+          <div class="panel panel-default">
+              <div class="panel-body">
+                  <button {{action "toggleDetail"}}>Toggle Detail View</button>
+                {{#liquid-if showDetail class='scrollThen-demo'}}
+                    <div class="details">
+                        <h3>Details</h3>
+
+                        <p>
+                            Bacon ipsum dolor amet shank pork belly boudin flank
+                            prosciutto alcatra andouille pig short ribs biltong kevin
+                            salami tail turkey beef ribs.
+                        </p>
+                    </div>
+                {{else}}
+                    <div class="overview">
+                        <h3>Welcome</h3>
+
+                        <p>This is the overview.</p>
+                    </div>
+                {{/liquid-if}}
+              </div>
+          </div>
+        {{!- END-SNIPPET }}
+
+          <p>The transition rule:</p>
+        {{code-snippet name="scrollThen-demo.js"}}
+
+          <p>The template:</p>
+        {{code-snippet name="scrollThen-demo.hbs"}}
+      </div>
+  {{/if}}
+
+  {{#if (is-equal activeTab 'scale')}}
+      <dt>scale</dt>
+      <dd>Scales in the old content and scales out the new one. It is also able to pass <a
+              href="http://julian.com/research/velocity/#duration" target="_blank">Velocity options</a> as an optional
+          parameter.
+      </dd>
+      <div class="well">
+        {{!- BEGIN-SNIPPET scale-demo }}
+          <div class="panel panel-default">
+              <div class="panel-body">
+                  <button {{action "toggleDetail"}}>Toggle Detail View</button>
+                {{#liquid-if showDetail class='scale-demo'}}
+                    <div class="details">
+                        <h3>Details</h3>
+
+                        <p>
+                            Bacon ipsum dolor amet shank pork belly boudin flank
+                            prosciutto alcatra andouille pig short ribs biltong kevin
+                            salami tail turkey beef ribs.
+                        </p>
+                    </div>
+                {{else}}
+                    <div class="overview">
+                        <h3>Welcome</h3>
+
+                        <p>This is the overview.</p>
+                    </div>
+                {{/liquid-if}}
+              </div>
+          </div>
+        {{!- END-SNIPPET }}
+      </div>
+  {{/if}}
+
+</div>

--- a/tests/dummy/app/transitions.js
+++ b/tests/dummy/app/transitions.js
@@ -1,8 +1,8 @@
 import Ember from "ember";
 
-export default function(){
+export default function () {
   if (Ember.testing) {
-    this.setDefault({duration: 10 });
+    this.setDefault({duration: 10});
   }
   // BEGIN-SNIPPET transition-demo
   this.transition(
@@ -20,7 +20,7 @@ export default function(){
   );
   // END-SNIPPET
 
-  var duration = Ember.testing ? 0: 1000;
+  var duration = Ember.testing ? 0 : 1000;
   // BEGIN-SNIPPET liquid-box-demo-transition
   this.transition(
     this.hasClass('vehicles'),
@@ -38,7 +38,7 @@ export default function(){
 
   this.transition(
     this.childOf("#interrupted-fade-demo"),
-    this.use('fade', { duration: Ember.testing ? 100 : 1500 })
+    this.use('fade', {duration: Ember.testing ? 100 : 1500})
   );
 
   // BEGIN-SNIPPET explode-demo-1
@@ -48,21 +48,21 @@ export default function(){
       pickOld: 'h3',                // Find an "h3" in the old template. This
                                     // can be any CSS selector.
 
-      use: ['toUp', { duration }]   // And animate it upward. This can
-                                    // be any arbitrary transition, and
-                                    // its optional parameters.
+      use: ['toUp', {duration}]   // And animate it upward. This can
+                                  // be any arbitrary transition, and
+                                  // its optional parameters.
 
     }, {
       pickNew: 'h3',                // Find an "h3" in the new template
 
-      use: ['toDown', { duration }] // And animate it downward.
+      use: ['toDown', {duration}] // And animate it downward.
 
     }, {
       // For everything else that didn't match the above, use a
       // fade. I'm giving the fade half as much duration because fade
       // includes both fading out and fading in steps, each of which
       // spends `duration` milliseconds.
-      use: ['fade', { duration: duration/2 }]
+      use: ['fade', {duration: duration / 2}]
     })
   );
   // END-SNIPPET
@@ -80,12 +80,53 @@ export default function(){
       // fly-to is a built in transition that animate the element
       // moving from the position of oldElement to the position of
       // newElement.
-      use: ['fly-to', { duration, easing: 'spring'}]
+      use: ['fly-to', {duration, easing: 'spring'}]
     })
   );
   // END-SNIPPET
 
+  // BEGIN-SNIPPET toLeft-demo
   this.transition(
+    this.hasClass('toLeft-demo'),
+    this.use('toLeft', {duration})
+  );
+  // END-SNIPPET
+
+  // BEGIN-SNIPPET crossFade-demo
+  this.transition(
+    this.hasClass('crossFade-demo'),
+    this.use('crossFade', {duration: duration * 2})
+  );
+  // END-SNIPPET
+
+  // BEGIN-SNIPPET fade-demo
+  this.transition(
+    this.hasClass('fade-demo'),
+    this.use('fade', {duration})
+  );
+  // END-SNIPPET
+
+  // BEGIN-SNIPPET scrollThen-demo
+  this.transition(
+    this.hasClass('scrollThen-demo'),
+    this.use('scrollThen', 'toLeft', {duration})
+  );
+  // END-SNIPPET
+
+  // BEGIN-SNIPPET scale-demo
+  this.transition(
+    this.hasClass('scale-demo'),
+    this.use('scale', {duration})
+  );
+  // END-SNIPPET
+
+
+/*  this.transition(
+    this.childOf("#transition-examples"),
+    this.use('fade', {duration: 1000})
+  );*/
+
+this.transition(
     this.childOf("#inline-serial-scenario"),
     this.use('fade', {duration: 1000})
   );
@@ -107,13 +148,13 @@ export default function(){
   this.transition(
     this.fromRoute('scenarios.nested-outlets.middle.index'),
     this.toRoute('scenarios.nested-outlets.middle.inner'),
-    this.use('fade', {duration: Ember.testing ? 10: 1000 }),
+    this.use('fade', {duration: Ember.testing ? 10 : 1000}),
     this.reverse('fade', {duration: Ember.testing ? 10 : 1000})
   );
 
   this.transition(
     this.childOf('#versions-test'),
-    this.use('fade', { duration: 500 })
+    this.use('fade', {duration: 500})
   );
 
   this.transition(
@@ -122,24 +163,24 @@ export default function(){
     this.use('explode', {
       pickOld: '.bluebox',
       pickNew: '.redbox',
-      use: ['flyTo', { duration: 1500 } ]
+      use: ['flyTo', {duration: 1500}]
     }, {
       pickOld: '.blue-abs-box',
       pickNew: '.red-abs-box',
-      use: ['flyTo', {duration: 1500 } ]
+      use: ['flyTo', {duration: 1500}]
     }, {
-      use: [ 'toLeft', { duration: 1500 } ]
+      use: ['toLeft', {duration: 1500}]
     }),
     this.reverse('explode', {
       pickOld: '.redbox',
       pickNew: '.bluebox',
-      use: ['flyTo', { duration: 1500 } ]
+      use: ['flyTo', {duration: 1500}]
     }, {
       pickOld: '.red-abs-box',
       pickNew: '.blue-abs-box',
-      use: ['flyTo', {duration: 1500 } ]
+      use: ['flyTo', {duration: 1500}]
     }, {
-      use: [ 'toRight', { duration: 1500 } ]
+      use: ['toRight', {duration: 1500}]
     })
   );
 
@@ -147,7 +188,7 @@ export default function(){
     this.hasClass('hero-sort'),
     this.use('explode', {
       matchBy: 'data-model-id',
-      use: ['flyTo', { duration: 500, easing: [250, 15] } ]
+      use: ['flyTo', {duration: 500, easing: [250, 15]}]
     })
   );
 
@@ -159,7 +200,7 @@ export default function(){
 
   this.transition(
     this.withinRoute(/^scenarios.model-dependent-rule\./),
-    this.fromModel(function(fromModel, toModel) {
+    this.fromModel(function (fromModel, toModel) {
       return fromModel && toModel && parseInt(fromModel.id) < parseInt(toModel.id);
     }),
     this.use('toLeft'),
@@ -169,20 +210,20 @@ export default function(){
   this.transition(
     this.fromRoute('scenarios.interrupted-move.index'),
     this.toRoute('scenarios.interrupted-move.two'),
-    this.use('toLeft', { duration: 1500 }),
-    this.reverse('toRight', { duration: 1500 })
+    this.use('toLeft', {duration: 1500}),
+    this.reverse('toRight', {duration: 1500})
   );
   this.transition(
     this.fromRoute('scenarios.interrupted-move.two'),
     this.toRoute('scenarios.interrupted-move.three'),
-    this.use('toLeft', { duration: 1500 }),
-    this.reverse('toRight', { duration: 1500 })
+    this.use('toLeft', {duration: 1500}),
+    this.reverse('toRight', {duration: 1500})
   );
   this.transition(
     this.fromRoute('scenarios.interrupted-move.index'),
     this.toRoute('scenarios.interrupted-move.three'),
-    this.use('toLeft', { duration: 1500 }),
-    this.reverse('toRight', { duration: 1500 })
+    this.use('toLeft', {duration: 1500}),
+    this.reverse('toRight', {duration: 1500})
   );
 
 }

--- a/tests/dummy/app/transitions.js
+++ b/tests/dummy/app/transitions.js
@@ -1,6 +1,6 @@
 import Ember from "ember";
 
-export default function () {
+export default function() {
   if (Ember.testing) {
     this.setDefault({duration: 10});
   }
@@ -119,12 +119,6 @@ export default function () {
     this.use('scale', {duration})
   );
   // END-SNIPPET
-
-
-/*  this.transition(
-    this.childOf("#transition-examples"),
-    this.use('fade', {duration: 1000})
-  );*/
 
 this.transition(
     this.childOf("#inline-serial-scenario"),


### PR DESCRIPTION
Hi,
It is really sad to see a great library that deals with animations and it does not provide an interactive showcase for **all** of these animations. Right now,iIndividual transitions are just described in a very brief textual way, but that is I guess not enough :(  People want to actually see these transitions in action before they decide to use them in their own project. I know... some of them are used here and there on the documentation page, but not all of them and (more importantly) not in one place.
I also found 2 transitions that weren't mentioned anywhere (_scrollThen_ and _scale_), so I created a documentation for them, too.

btw. sorry for the way I implemented tabs in _predefined.hbs_ template... I guess it would be much nicer to create nested routes for each of them and not cram averything into one template... but I am just too lazy...