### PR TITLE
Add lf-modal-closing class while a modal closing

### DIFF
--- a/app/components/lf-overlay.js
+++ b/app/components/lf-overlay.js
@@ -17,7 +17,7 @@ export default Ember.Component.extend({
     var counter = body.data(COUNTER) || 0;
     body.data(COUNTER, counter-1);
     if (counter < 2) {
-      body.removeClass('lf-modal-open');
+      body.removeClass('lf-modal-open lf-modal-closing');
     }
   }
 });

--- a/app/components/liquid-modal.js
+++ b/app/components/liquid-modal.js
@@ -73,6 +73,7 @@ export default Ember.Component.extend({
       }
     },
     dismiss: function() {
+      Ember.$('body').addClass('lf-modal-closing');
       var source = this.get('currentContext.source'),
           proto = source.constructor.proto(),
           params = this.get('currentContext.options.withParams'),


### PR DESCRIPTION
If `liquid-if` and multiple components are used in modals, closing a modal would take noticeable time. as `liquid-if` will set `visibility:visible;` explicitly to `liquid-child`'s `style` attribute. it always happens that the modal has disappeared whereas the content inside is still visible. so I added `lf-modal-closing` class so that if a modal in a closing process, it is easy to set `visibility: inherit !important` to `liquid-child` to hide content inside while closing a modal.