### PR TITLE
[FASTBOOT] Guard Against Browser v. Node

### DIFF
--- a/addon/is-browser.js
+++ b/addon/is-browser.js
@@ -1,0 +1,3 @@
+export default function isBrowser() {
+  return (typeof window !== 'undefined') && window && (typeof document !== 'undefined') && document;
+}

--- a/addon/mutation-observer.js
+++ b/addon/mutation-observer.js
@@ -1,3 +1,4 @@
+import isBrowser from './is-browser';
 var activePollers = [];
 
 function MutationPoller(callback){
@@ -15,7 +16,13 @@ MutationPoller.prototype = {
   }
 };
 
-var M = (window.MutationObserver || window.WebkitMutationObserver || MutationPoller);
+var M;
+if (isBrowser()) {
+  M = (window.MutationObserver || window.WebkitMutationObserver || MutationPoller);
+} else {
+  M = MutationPoller;
+}
+
 
 export default M;
 

--- a/app/components/lm-container.js
+++ b/app/components/lm-container.js
@@ -8,6 +8,7 @@
 
 import Ember from "ember";
 import "liquid-fire/tabbable";
+import isBrowser from "liquid-fire/is-browser";
 
 /**
  * If you do something to move focus outside of the browser (like
@@ -16,7 +17,11 @@ import "liquid-fire/tabbable";
  * modal.
  */
 var lastOpenedModal = null;
-Ember.$(document).on('focusin', handleTabIntoBrowser);
+
+if (isBrowser()) {
+  Ember.$(document).on('focusin', handleTabIntoBrowser);
+}
+
 
 function handleTabIntoBrowser() {
   if (lastOpenedModal) {

--- a/app/transitions/scroll-then.js
+++ b/app/transitions/scroll-then.js
@@ -1,27 +1,30 @@
 import Ember from 'ember';
+import isBrowser from "liquid-fire/is-browser";
 
 export default function(nextTransitionName, options, ...rest) {
-  Ember.assert(
-    "You must provide a transition name as the first argument to scrollThen. Example: this.use('scrollThen', 'toLeft')",
-    'string' === typeof nextTransitionName
-  );
+  if (isBrowser()) {
+    Ember.assert(
+      "You must provide a transition name as the first argument to scrollThen. Example: this.use('scrollThen', 'toLeft')",
+      'string' === typeof nextTransitionName
+    );
 
-  var el = document.getElementsByTagName('html');
-  var nextTransition = this.lookup(nextTransitionName);
-  if (!options) {  options = {}; }
+    var el = document.getElementsByTagName('html');
+    var nextTransition = this.lookup(nextTransitionName);
+    if (!options) {  options = {}; }
 
-  Ember.assert(
-    "The second argument to scrollThen is passed to Velocity's scroll function and must be an object",
-    'object' === typeof options
-  );
+    Ember.assert(
+      "The second argument to scrollThen is passed to Velocity's scroll function and must be an object",
+      'object' === typeof options
+    );
 
-  // set scroll options via: this.use('scrollThen', 'ToLeft', {easing: 'spring'})
-  options = Ember.merge({duration: 500, offset: 0}, options);
+    // set scroll options via: this.use('scrollThen', 'ToLeft', {easing: 'spring'})
+    options = Ember.merge({duration: 500, offset: 0}, options);
 
-  // additional args can be passed through after the scroll options object
-  // like so: this.use('scrollThen', 'moveOver', {duration: 100}, 'x', -1);
+    // additional args can be passed through after the scroll options object
+    // like so: this.use('scrollThen', 'moveOver', {duration: 100}, 'x', -1);
 
-  return window.$.Velocity(el, 'scroll', options).then(() => {
-    nextTransition.apply(this, rest);
-  });
+    return window.$.Velocity(el, 'scroll', options).then(() => {
+      nextTransition.apply(this, rest);
+    });
+  }
 }

--- a/packaging/glue.js
+++ b/packaging/glue.js
@@ -1,43 +1,45 @@
 /* global define, require */
 
-define('ember', ["exports"], function(__exports__) {
-  __exports__['default'] = window.Ember;
-});
-define('liquid-fire', ["exports"], function(__exports__) {
-  var lf = require('liquid-fire/index');
-  Object.keys(lf).forEach(function(key) {
-    __exports__[key] = lf[key];
+if (require('liquid-fire/is-browser')['default']()) {
+  define('ember', ["exports"], function(__exports__) {
+    __exports__['default'] = window.Ember;
   });
-});
-
-window.LiquidFire = require('liquid-fire/index');
-window.LiquidFire._deferredMaps = [];
-window.LiquidFire._deferredDefines = [];
-
-window.LiquidFire.map = function(handler) {
-  window.LiquidFire._deferredMaps.push(handler);
-};
-
-window.LiquidFire.defineTransition = function(name, implementation) {
-  window.LiquidFire._deferredDefines.push([name, implementation]);
-};
-
-window.Ember.Application.initializer({
-  name: 'liquid-fire-standalone',
-  initialize: function(container) {
-    require('liquid-fire-shim').initialize(container);
-    require('liquid-fire/index').initialize(container);
-
-    window.LiquidFire._deferredDefines.forEach(function(pair){
-      container.register('transition:' + pair[0], pair[1]);
+  define('liquid-fire', ["exports"], function(__exports__) {
+    var lf = require('liquid-fire/index');
+    Object.keys(lf).forEach(function(key) {
+      __exports__[key] = lf[key];
     });
+  });
 
-    container.register('transitions:main', function() {
-      var self = this;
-      window.LiquidFire._deferredMaps.forEach(function(m){
-        m.apply(self);
+  window.LiquidFire = require('liquid-fire/index');
+  window.LiquidFire._deferredMaps = [];
+  window.LiquidFire._deferredDefines = [];
+
+  window.LiquidFire.map = function(handler) {
+    window.LiquidFire._deferredMaps.push(handler);
+  };
+
+  window.LiquidFire.defineTransition = function(name, implementation) {
+    window.LiquidFire._deferredDefines.push([name, implementation]);
+  };
+
+  window.Ember.Application.initializer({
+    name: 'liquid-fire-standalone',
+    initialize: function(container) {
+      require('liquid-fire-shim').initialize(container);
+      require('liquid-fire/index').initialize(container);
+
+      window.LiquidFire._deferredDefines.forEach(function(pair){
+        container.register('transition:' + pair[0], pair[1]);
       });
-    });
 
-  }
-});
+      container.register('transitions:main', function() {
+        var self = this;
+        window.LiquidFire._deferredMaps.forEach(function(m){
+          m.apply(self);
+        });
+      });
+
+    }
+  });
+}


### PR DESCRIPTION
If you are using liquid-fire and fastboot, you're going to have a bad
time. This guards `window` and `document` references that occur out of
`didInstertElement` hooks.

Ember needs to expose a better way with dealing with this.