### PR TITLE
Fixes loading substates not being called when liquid fire is used

### DIFF
--- a/addon/router-dsl-ext.js
+++ b/addon/router-dsl-ext.js
@@ -32,7 +32,7 @@ proto.modal = function(componentName, opts) {
 Router.reopen({
   _initRouterJs: function() {
     currentMap = [];
-    this._super();
+    this._super.apply(this, arguments);
     this.router.modals = currentMap;
   }
 });


### PR DESCRIPTION
The problem was a monkey patch not properly forwarding arguments to the superclass.