### PR TITLE
Fix getOwner container deprecations for Canary.

### DIFF
--- a/addon/modal.js
+++ b/addon/modal.js
@@ -1,4 +1,5 @@
 import Ember from "ember";
+import getOwner from 'ember-getowner-polyfill';
 var get = Ember.get;
 
 
@@ -10,9 +11,9 @@ export default Ember.Object.extend({
 
   controller: Ember.computed('enabled', function() {
     if (!get(this, 'enabled')) { return; }
-    var container = get(this, 'container');
+    var owner = getOwner(this);
     var name = get(this, 'options.controller') || get(this, 'route');
-    return container.lookup('controller:' + name);
+    return owner.lookup('controller:' + name);
   }),
 
   update: Ember.observer('controller', Ember.on('init', function() {

--- a/addon/transition-map.js
+++ b/addon/transition-map.js
@@ -4,13 +4,15 @@ import Ember from "ember";
 import Action from "./action";
 import internalRules from "./internal-rules";
 import Constraints from "./constraints";
+import getOwner from 'ember-getowner-polyfill';
 
 var TransitionMap = Ember.Service.extend({
   init: function() {
     this.activeCount = 0;
     this.constraints = new Constraints();
     this.map(internalRules);
-    var config = this.container.lookupFactory('transitions:main');
+    var owner = getOwner(this);
+    var config = owner._lookupFactory('transitions:main');
     if (config) {
       this.map(config);
     }
@@ -56,7 +58,8 @@ var TransitionMap = Ember.Service.extend({
   },
 
   lookup: function(transitionName) {
-    var handler = this.container.lookupFactory('transition:' + transitionName);
+    var owner = getOwner(this);
+    var handler = owner._lookupFactory('transition:' + transitionName);
     if (!handler) {
       throw new Error("unknown transition name: " + transitionName);
     }

--- a/app/components/liquid-modal.js
+++ b/app/components/liquid-modal.js
@@ -1,4 +1,5 @@
 import Ember from "ember";
+import getOwner from 'ember-getowner-polyfill';
 
 export default Ember.Component.extend({
   classNames: ['liquid-modal'],
@@ -15,8 +16,8 @@ export default Ember.Component.extend({
   innerView: function(current) {
     var self = this,
         name = current.get('name'),
-        container = this.get('container'),
-        component = container.lookup('component-lookup:main').lookupFactory(name);
+        owner = getOwner(this),
+        component = owner.lookup('component-lookup:main').lookupFactory(name);
     Ember.assert("Tried to render a modal using component '" + name + "', but couldn't find it.", !!component);
 
     var args = Ember.copy(current.get('params'));

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "ember": "components/ember#canary",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-qunit": "0.4.11",
+    "ember-qunit": "0.4.16",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.15",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "ember-cli-babel": "^5.0.0",
     "ember-cli-htmlbars": "0.7.6",
     "ember-cli-version-checker": "^1.0.2",
+    "ember-getowner-polyfill": "^0.1.2",
     "match-media": "^0.2.0",
     "velocity-animate": ">= 0.11.8"
   },
@@ -35,7 +36,7 @@
     "ember-cli-dependency-checker": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-code-snippet": "^1.0.0",
-    "ember-cli-qunit": "1.0.3",
+    "ember-cli-qunit": "^1.0.3",
     "ember-cli-uglify": "^1.0.1",
     "ember-giftwrap": "0.0.2",
     "git-repo-info": "^1.0.4",

--- a/tests/unit/libs/dsl-test.js
+++ b/tests/unit/libs/dsl-test.js
@@ -1,10 +1,22 @@
 import Ember from "ember";
 import Application from '../../../app';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
 var application, t, defaultHandler;
 
 Ember.run(function(){
-  application = Application.create({ autoboot: false});
+  var options = {
+    autoboot: false
+  };
+
+  if (hasEmberVersion(2,2) && !hasEmberVersion(2,3)) {
+    // autoboot: false does not work in Ember 2.2 (it was never public API),
+    // this prevents various things from happening that cause failures (like
+    // starting the event dispatcher on `body`)
+    options._bootSync = function() { };
+  }
+
+  application = Application.create(options);
 });
 
 module("Transitions DSL", {


### PR DESCRIPTION
As of Ember 2.3, using `this.container` from within an instance that is looked up from the container will issue a deprecation warning suggesting that you should refactor away from the private `this.container` usage to the new public API for using container/registry features (`Ember.getOwner(this)`).

This change pulls in the `ember-getowner-polyfill` to allow us to use `getOwner` on all Ember versions (tested back to 1.10 in that addon's CI).