### PR TITLE
Update ember-getowner-polyfill to allow SemVer drift.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ember-cli-babel": "^5.0.0",
     "ember-cli-htmlbars": "0.7.6",
     "ember-cli-version-checker": "^1.0.2",
-    "ember-getowner-polyfill": "^0.1.2",
+    "ember-getowner-polyfill": "^1.0.0",
     "match-media": "^0.2.0",
     "velocity-animate": ">= 0.11.8"
   },


### PR DESCRIPTION
1.0.0 is not a breaking change (more of a solidification of the API).