### PR TITLE
Remove statement re: June 2015 version bump

### DIFF
--- a/tests/dummy/app/templates/installation.hbs
+++ b/tests/dummy/app/templates/installation.hbs
@@ -34,6 +34,4 @@ For Ember &lt; 1.11.0
 
 <p>As liquid-fire is still pre-1.0, you can expect breaking changes,
 which will be described in the <a
-href="https://github.com/ef4/liquid-fire/blob/master/CHANGELOG.md">CHANGELOG</a>. We
-plan to stabilize the API and publish a 1.0 beta in conjunction with
-the Ember 2.0 beta in June 2015.</p>
+href="https://github.com/ef4/liquid-fire/blob/master/CHANGELOG.md">CHANGELOG</a>.</p>


### PR DESCRIPTION
I'm glad to see that liquid-fire is still under active development as it's a super valuable part of the Ember ecosystem. However, the docs still claim [here](http://ef4.github.io/liquid-fire/#/installation) that `We plan to stabilize the API and publish a 1.0 beta in conjunction with the Ember 2.0 beta in June 2015.` Since this landmark has come and gone by 6 months, having this statement remain in the docs may come across as though liquid-fire has been abandoned (which by all other measures does not seem to be the case).

Ideally, it would be nice to see this sentence updated with any current information, but in the meantime it may be best to just remove this sentence altogether (as this PR proposes).