### PR TITLE
Add fix for using LF as an addon inside an addon

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,11 @@ module.exports = {
   },
 
   included: function(app){
+    // see: https://github.com/ember-cli/ember-cli/issues/3718
+    if (typeof app.import !== 'function' && app.app) {
+      app = app.app;
+    }
+
     if (!process.env.EMBER_CLI_FASTBOOT) {
       app.import('vendor/velocity/velocity.js');
       app.import('vendor/match-media/matchMedia.js');


### PR DESCRIPTION
Fixes the following error:

```no-highlight
version: 1.13.13
app.import is not a function
TypeError: app.import is not a function
    at Class.module.exports.included (/Users/me/my-addon/node_modules/liquid-fire/index.js:34:17)
```